### PR TITLE
Blame history

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -444,19 +444,14 @@ module.exports = function(options) {
         }
       } else {
         // The attribute was deleted
+        if(historyJson[i]) {
+          delete historyJson[i]
+          modified = true
+        }
 
-        // TODO !!!???  (NOT SURE ON BEHAVIOUR -> SAVE INFO OR?)
-
-        console.log("Deleted attribute " + i)
-        if (typeof i == 'string') {
-          console.log("Its a string")
-          // idk
-        } else if (i instanceof Array) {
-          console.log("Its an array")
-          // idk
-        } else if (typeof i == 'object') {
-          console.log("Its an object")
-          // idk
+        if (historyJson["$hist_" + i]) {
+          delete historyJson["$hist_" + i]
+          modified = true
         }
       }
     }

--- a/src/collection.js
+++ b/src/collection.js
@@ -3,6 +3,7 @@ var Repository = require('./repository')
 var fs = require('fs')
 var Promise = require('promise')
 var mkdirp = require('mkdirp')
+var historyGenerator = require('./history-generator')
 
 var write = Promise.denodeify(fs.writeFile)
 var read = Promise.denodeify(fs.readFile)
@@ -205,265 +206,28 @@ module.exports = function(options) {
     })
   }
 
-  var getSmallestCommitPath = function(index, commitPath, callback) {
-    repo.branchExists("hist_" + commitPath[index].commit, function(result) {
-      if (result) {
-        // TO ADD: A CHECK HERE IF THE HISTORY BRANCH IS VALID ON THIS COMMITPATH
-        var slicedPath = commitPath.slice(0,index+1)
-        console.log(slicedPath)
-        callback(slicedPath)
-      } else if (index+1 == commitPath.length) {
-        callback(commitPath)
-      }
-      else {
-        getSmallestCommitPath(index+1, commitPath, callback)
-      }
-    })
-  }
-
-  var updateHistory = function(callback) {
-    console.log("UPDATE HISTORY CALLED ON BRANCH " + branch)
-    // get the commit path for this branch
-    repo.checkout(branch, function() {
-      repo.jsonLog(branch + ' -s ', function(commitPath) {
-        // slice the path if there already exists a history branch
-        getSmallestCommitPath(0, commitPath, function(slicedPath) {
-          if (commitPath != slicedPath) {
-            // We found a history branch! Let's use this & previous commit
-            console.log("History found in commit path")
-            orderedCommits = slicedPath.reverse()
-            branchToObj("hist_" + orderedCommits[0].commit, function(historyJson) {
-              getSharedCommits(branch, function(sharedCommits) {
-                currentCommit = orderedCommits[0]
-                orderedCommits.shift()
-                createHistory(currentCommit, orderedCommits, sharedCommits, historyJson, function(result) { 
-                  callback(result)
-                })
-              })
-            })
-          } else {
-            // We must create the history from scratch!
-            console.log("Making history from scratch")
-            slicedPath.push({})
-            orderedCommits = slicedPath.reverse()
-            getSharedCommits(branch, function(sharedCommits) {
-              currentCommit = orderedCommits[0]
-              orderedCommits.shift()
-              createHistory(currentCommit, orderedCommits, sharedCommits, {}, function(result) { 
-                callback(result)
-              })
-            })
-          }
-        })
+  var history = function(callback) {
+    repo.jsonLog(branch + ' -s ', function(commits) {
+      
+      loadCommits(commits.reverse(), [], function(commitDatas) {
+        var history = historyGenerator(commitDatas)
+        callback(history)  
       })
     })
   }
 
-  var getSharedCommits = function(branch, callback) {
-    repo.checkout(branch, function() {
-      repo.branchList(function(branches) {
-        var mergeBases = []
-        branches = (branches.split('\n')).slice(0,-1)
-        console.log(branches)
-        var promises = branches
-          .map(f => new Promise(function(done) {
-            repo.mergeBase(branch, f.substring(1), function(result) {
-              mergeBases.push(result.trim())
-              done()
-            })
-          }))
+  var loadCommits = function(commits, commitDatas, callback) {
+    if (commits.length > 0) {
+      var commit = commits.shift()
 
-        Promise.all(promises).then(function() {
-          callback(mergeBases)
-        })
-      })
-    })
-  }
-
-  var createHistory = function(previousCommit, commitPath, sharedCommits, json, callback) {
-    
-    console.log("Create History called!")
-    console.log("Previous Commit = " + previousCommit.commit)
-    console.log("CommitPath length = " + commitPath.length)
-
-    if (commitPath.length > 0) {
-      currentCommit = commitPath[0]
-      console.log("Updating commit " + previousCommit.commit)
-      console.log("   using commit " + currentCommit.commit)
-
-      updateJson(previousCommit, currentCommit, json, function(result) {
-        // create branch and commit this new json bruh
-        console.log("Recursive call to create history")
-        createHistory(currentCommit, commitPath.slice(1), sharedCommits, result, callback)
+      branchToObj(commit.commit, function(obj) {
+        obj.$commit = commit
+        commitDatas.push(obj)
+        loadCommits(commits, commitDatas, callback)
       })
     } else {
-      // Create a history branch @ previous commit
-      var historybranch = "hist_" + previousCommit.commit
-      repo.branchExists(historybranch, function(result) {
-        // The history branch exists
-        if(result) {
-          console.log("History exists, returning")
-          repo.checkout(branch, function() {
-            callback(json)
-          })
-        } else {
-          console.log("Created history branch @ " + historybranch)
-          repo.checkout(previousCommit.commit, function() {
-            repo.branch(historybranch, function() {
-              repo.checkout(historybranch, function() {
-                objToBranch(json, historybranch, function() {
-                  console.log("Saved the history")
-                  repo.checkout(branch, function() {
-                    callback(json)
-                  })
-                })
-              })
-            })
-          })
-        }
-      })
+      callback(commitDatas)
     }
-  }
-
-  var updateJson = function(oldCommitInfo, newCommitInfo, historyJson, callback) {
-    // convert this commit to an obj
-    branchToObj(newCommitInfo.commit, function(newCommitJson) {
-      // compare the jsons, returns new updated json
-      if (!oldCommitInfo.commit) {
-        //console.log("INITIAL COMMIT")
-        compareJson({}, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
-          callback(resultJson)
-        })
-      } else {
-        //console.log("UPDATING COMMIT")
-        branchToObj(oldCommitInfo.commit, function(oldCommitJson) {
-          compareJson(oldCommitJson, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
-            callback(resultJson)
-          })
-        })
-      }
-    })
-  }
-
-  // Compares two json files with optional historyjson, returning the difference as a history JSON w/ commit info
-  var compareJson = function(oldCommitJson, newCommitJson, historyJson, newCommitInfo, callback) {
-
-    var modified = false
-
-    // debug info (believe me its damn useful LOL)
-    // console.log("Comparing jsons")
-    // console.log("New: " + (typeof newCommitJson) + JSON.stringify(newCommitJson))
-    // console.log("Old: " + (typeof oldCommitJson) + JSON.stringify(oldCommitJson))
-    // console.log("Hist: " + (typeof historyJson) + JSON.stringify(historyJson))
-
-    // Iterate through all the keys in newCommitJson, looking for new attributes 
-    for (var i in newCommitJson) {
-
-      // If the attribute doesnt exist in the old Json OR the old json isnt an object..
-      if (!(typeof oldCommitJson == 'object') || !(i in oldCommitJson)) {
-        newVersion = newCommitJson[i]
-        console.log("New attribute " + i  + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
-        if (newVersion instanceof Array) {
-            // The newversion is an array
-
-            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
-
-        } else if (typeof newVersion == 'object') {
-          //The newversion is an object
-
-          //Compare the children json with empty json - makes all children new basically
-          compareJson({}, newVersion, {}, newCommitInfo, function(extractModified, jsonExtract) { 
-            // Add parent history
-            historyJson[i] = jsonExtract
-            historyJson["$hist_" + i] = "Created by " + newCommitInfo.author + " at " + newCommitInfo.date
-            modified = true
-          })
-        } else {
-          // The newversion is a variable
-
-          // Add it to the json and history 
-          historyJson[i] = newVersion
-          historyJson["$hist_" + i] = "Created with value '" + newVersion + "' by " + newCommitInfo.author + " at " + newCommitInfo.date
-          modified = true
-        }
-      }
-    }
-
-    // Iterate through all the keys in oldCommitJson, looking for updates and deletions
-    for (var i in oldCommitJson) {
-
-      // The key exists in both the old and new object
-      if (i in newCommitJson && (typeof newCommitJson == 'object')) {
-        oldVersion = oldCommitJson[i]
-        newVersion = newCommitJson[i]
-
-        // The old ver is not equal to the new ver
-        // Note - object comparison always returns false -> we need a 'modified' parameter in this circumstance 
-        if (oldVersion !== newVersion) {
-          // should be an index in history.json unless something is broken..
-          console.log("Updated attribute " + i + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
-          
-          // Additional information for any type conversion that occurs from old -> new
-          typeConversion = ""
-          if (typeof newVersion !== typeof oldVersion) {
-            typeConversion = " - Changed type from " + (typeof oldVersion) + " to " + (typeof newVersion)
-          } 
-
-          if (newVersion instanceof Array) {
-            // The newversion is an array
-
-            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
-
-            modified = true
-          } else if (typeof newVersion == 'object') {
-            // The newversion is an object
-
-            // If the old version is not an object, its gotta be removed
-            if (typeof oldVersion !== 'object') {
-              oldVersion = {}
-              historyJson[i] = {} 
-            }
-
-            // Compare the children json files, using the history for updates
-            compareJson(oldVersion, newVersion, historyJson[i], newCommitInfo, function(extractModified, jsonExtract) {
-              if (extractModified) {
-                // The extract was modified from old -> new
-                // Update parent history
-                historyJson[i] = jsonExtract
-                historyJson["$hist_" + i] = "Modified by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
-                modified = true
-              }
-            })
-          } else {
-            // The newversion is a variable
-            // Update variable & history
-            historyJson[i] = newVersion
-            historyJson["$hist_" + i] += "\nUpdated with value '" + newVersion + " by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
-            modified = true
-          }
-        }
-      } else {
-        // The attribute was deleted
-        if(historyJson[i]) {
-          delete historyJson[i]
-          modified = true
-        }
-
-        if (historyJson["$hist_" + i]) {
-          delete historyJson["$hist_" + i]
-          modified = true
-        }
-      }
-    }
-
-    // Return whether the json was modified + changed file
-    callback(modified, historyJson)
-  }
-
-  var getHistory = function(logOptions, callback) {
-    repo.jsonLog(logOptions + ' ' + branch, function(result) {
-      callback(result)
-    })
   }
 
   var changeBranch = function(newbranch, callback) {
@@ -612,9 +376,8 @@ module.exports = function(options) {
     load: load,
     save: save,
     createBranch: createBranch,
-    updateHistory: updateHistory,
+    history:history,
     merge: merge,
-    getHistory: getHistory,
     branchList: branchList
   }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -193,7 +193,7 @@ module.exports = function(options) {
   }
 
   var getHistory = function(logOptions, callback) {
-    repo.log(logOptions + ' ' + branch, function(result) {
+    repo.jsonLog(logOptions + ' ' + branch, function(result) {
       //console.log(result)
       callback(result)
     })

--- a/src/collection.js
+++ b/src/collection.js
@@ -112,9 +112,8 @@ module.exports = function(options) {
           repo.merge(" --abort", function() {
             console.log("Merge conflict : ")
             console.log(output)
-            resolveConflict(fromBranch)
+            resolveConflict(fromBranch,callback)
           })
-          callback(err)
         } else {
           callback()
         }
@@ -151,6 +150,7 @@ module.exports = function(options) {
           leftObj = leftObj
           branchToObj(mergeToBranch, function(rightObj) {
             rightObj = rightObj
+            callback()
             // diff(baseObj, leftObj, rightObj, function() {
             //   callback()
             // })
@@ -192,9 +192,281 @@ module.exports = function(options) {
     })
   }
 
+  var objToBranch = function (obj, branchToSave, callback) {
+    var promises = Object.getOwnPropertyNames(obj)
+      .map(p => write(path.join(userroot, p + '.json'), JSON.stringify(obj[p], null, 2)))
+
+    Promise.all(promises).then(function() {
+      addAndCommit(branchToSave, function() {
+        repo.push(" origin " + branchToSave, function() {
+          callback()
+        })
+      })
+    })
+  }
+
+  var getSmallestCommitPath = function(index, commitPath, callback) {
+    repo.branchExists("hist_" + commitPath[index].commit, function(result) {
+      if (result) {
+        // TO ADD: A CHECK HERE IF THE HISTORY BRANCH IS VALID ON THIS COMMITPATH
+        var slicedPath = commitPath.slice(0,index+1)
+        console.log(slicedPath)
+        callback(slicedPath)
+      } else if (index+1 == commitPath.length) {
+        callback(commitPath)
+      }
+      else {
+        getSmallestCommitPath(index+1, commitPath, callback)
+      }
+    })
+  }
+
+  var updateHistory = function(callback) {
+    console.log("UPDATE HISTORY CALLED ON BRANCH " + branch)
+    // get the commit path for this branch
+    repo.checkout(branch, function() {
+      repo.jsonLog(branch + ' -s ', function(commitPath) {
+        // slice the path if there already exists a history branch
+        getSmallestCommitPath(0, commitPath, function(slicedPath) {
+          if (commitPath != slicedPath) {
+            // We found a history branch! Let's use this & previous commit
+            console.log("History found in commit path")
+            orderedCommits = slicedPath.reverse()
+            branchToObj("hist_" + orderedCommits[0].commit, function(historyJson) {
+              getSharedCommits(branch, function(sharedCommits) {
+                currentCommit = orderedCommits[0]
+                orderedCommits.shift()
+                createHistory(currentCommit, orderedCommits, sharedCommits, historyJson, function(result) { 
+                  callback(result)
+                })
+              })
+            })
+          } else {
+            // We must create the history from scratch!
+            console.log("Making history from scratch")
+            slicedPath.push({})
+            orderedCommits = slicedPath.reverse()
+            getSharedCommits(branch, function(sharedCommits) {
+              currentCommit = orderedCommits[0]
+              orderedCommits.shift()
+              createHistory(currentCommit, orderedCommits, sharedCommits, {}, function(result) { 
+                callback(result)
+              })
+            })
+          }
+        })
+      })
+    })
+  }
+
+  var getSharedCommits = function(branch, callback) {
+    repo.checkout(branch, function() {
+      repo.branchList(function(branches) {
+        var mergeBases = []
+        branches = (branches.split('\n')).slice(0,-1)
+        console.log(branches)
+        var promises = branches
+          .map(f => new Promise(function(done) {
+            repo.mergeBase(branch, f.substring(1), function(result) {
+              mergeBases.push(result.trim())
+              done()
+            })
+          }))
+
+        Promise.all(promises).then(function() {
+          callback(mergeBases)
+        })
+      })
+    })
+  }
+
+  var createHistory = function(previousCommit, commitPath, sharedCommits, json, callback) {
+    
+    console.log("Create History called!")
+    console.log("Previous Commit = " + previousCommit.commit)
+    console.log("CommitPath length = " + commitPath.length)
+
+    if (commitPath.length > 0) {
+      currentCommit = commitPath[0]
+      console.log("Updating commit " + previousCommit.commit)
+      console.log("   using commit " + currentCommit.commit)
+
+      updateJson(previousCommit, currentCommit, json, function(result) {
+        // create branch and commit this new json bruh
+        console.log("Recursive call to create history")
+        createHistory(currentCommit, commitPath.slice(1), sharedCommits, result, callback)
+      })
+    } else {
+      // Create a history branch @ previous commit
+      var historybranch = "hist_" + previousCommit.commit
+      repo.branchExists(historybranch, function(result) {
+        // The history branch exists
+        if(result) {
+          console.log("History exists, returning")
+          repo.checkout(branch, function() {
+            callback(json)
+          })
+        } else {
+          console.log("Created history branch @ " + historybranch)
+          repo.checkout(previousCommit.commit, function() {
+            repo.branch(historybranch, function() {
+              repo.checkout(historybranch, function() {
+                objToBranch(json, historybranch, function() {
+                  console.log("Saved the history")
+                  repo.checkout(branch, function() {
+                    callback(json)
+                  })
+                })
+              })
+            })
+          })
+        }
+      })
+    }
+  }
+
+  var updateJson = function(oldCommitInfo, newCommitInfo, historyJson, callback) {
+    // convert this commit to an obj
+    branchToObj(newCommitInfo.commit, function(newCommitJson) {
+      // compare the jsons, returns new updated json
+      if (!oldCommitInfo.commit) {
+        //console.log("INITIAL COMMIT")
+        compareJson({}, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
+          callback(resultJson)
+        })
+      } else {
+        //console.log("UPDATING COMMIT")
+        branchToObj(oldCommitInfo.commit, function(oldCommitJson) {
+          compareJson(oldCommitJson, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
+            callback(resultJson)
+          })
+        })
+      }
+    })
+  }
+
+  // Compares two json files with optional historyjson, returning the difference as a history JSON w/ commit info
+  var compareJson = function(oldCommitJson, newCommitJson, historyJson, newCommitInfo, callback) {
+
+    var modified = false
+
+    // debug info (believe me its damn useful LOL)
+    // console.log("Comparing jsons")
+    // console.log("New: " + (typeof newCommitJson) + JSON.stringify(newCommitJson))
+    // console.log("Old: " + (typeof oldCommitJson) + JSON.stringify(oldCommitJson))
+    // console.log("Hist: " + (typeof historyJson) + JSON.stringify(historyJson))
+
+    // Iterate through all the keys in newCommitJson, looking for new attributes 
+    for (var i in newCommitJson) {
+
+      // If the attribute doesnt exist in the old Json OR the old json isnt an object..
+      if (!(typeof oldCommitJson == 'object') || !(i in oldCommitJson)) {
+        newVersion = newCommitJson[i]
+        console.log("New attribute " + i  + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
+        if (newVersion instanceof Array) {
+            // The newversion is an array
+
+            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
+
+        } else if (typeof newVersion == 'object') {
+          //The newversion is an object
+
+          //Compare the children json with empty json - makes all children new basically
+          compareJson({}, newVersion, {}, newCommitInfo, function(extractModified, jsonExtract) { 
+            // Add parent history
+            historyJson[i] = jsonExtract
+            historyJson["$hist_" + i] = "Created by " + newCommitInfo.author + " at " + newCommitInfo.date
+            modified = true
+          })
+        } else {
+          // The newversion is a variable
+
+          // Add it to the json and history 
+          historyJson[i] = newVersion
+          historyJson["$hist_" + i] = "Created with value '" + newVersion + "' by " + newCommitInfo.author + " at " + newCommitInfo.date
+          modified = true
+        }
+      }
+    }
+
+    // Iterate through all the keys in oldCommitJson, looking for updates and deletions
+    for (var i in oldCommitJson) {
+
+      // The key exists in both the old and new object
+      if (i in newCommitJson && (typeof newCommitJson == 'object')) {
+        oldVersion = oldCommitJson[i]
+        newVersion = newCommitJson[i]
+
+        // The old ver is not equal to the new ver
+        // Note - object comparison always returns false -> we need a 'modified' parameter in this circumstance 
+        if (oldVersion !== newVersion) {
+          // should be an index in history.json unless something is broken..
+          console.log("Updated attribute " + i + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
+          
+          // Additional information for any type conversion that occurs from old -> new
+          typeConversion = ""
+          if (typeof newVersion !== typeof oldVersion) {
+            typeConversion = " - Changed type from " + (typeof oldVersion) + " to " + (typeof newVersion)
+          } 
+
+          if (newVersion instanceof Array) {
+            // The newversion is an array
+
+            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
+
+            modified = true
+          } else if (typeof newVersion == 'object') {
+            // The newversion is an object
+
+            // If the old version is not an object, its gotta be removed
+            if (typeof oldVersion !== 'object') {
+              oldVersion = {}
+              historyJson[i] = {} 
+            }
+
+            // Compare the children json files, using the history for updates
+            compareJson(oldVersion, newVersion, historyJson[i], newCommitInfo, function(extractModified, jsonExtract) {
+              if (extractModified) {
+                // The extract was modified from old -> new
+                // Update parent history
+                historyJson[i] = jsonExtract
+                historyJson["$hist_" + i] = "Modified by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
+                modified = true
+              }
+            })
+          } else {
+            // The newversion is a variable
+            // Update variable & history
+            historyJson[i] = newVersion
+            historyJson["$hist_" + i] += "\nUpdated with value '" + newVersion + " by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
+            modified = true
+          }
+        }
+      } else {
+        // The attribute was deleted
+
+        // TODO !!!???  (NOT SURE ON BEHAVIOUR -> SAVE INFO OR?)
+
+        console.log("Deleted attribute " + i)
+        if (typeof i == 'string') {
+          console.log("Its a string")
+          // idk
+        } else if (i instanceof Array) {
+          console.log("Its an array")
+          // idk
+        } else if (typeof i == 'object') {
+          console.log("Its an object")
+          // idk
+        }
+      }
+    }
+
+    // Return whether the json was modified + changed file
+    callback(modified, historyJson)
+  }
+
   var getHistory = function(logOptions, callback) {
     repo.jsonLog(logOptions + ' ' + branch, function(result) {
-      //console.log(result)
       callback(result)
     })
   }
@@ -345,6 +617,7 @@ module.exports = function(options) {
     load: load,
     save: save,
     createBranch: createBranch,
+    updateHistory: updateHistory,
     merge: merge,
     getHistory: getHistory,
     branchList: branchList

--- a/src/history-generator.js
+++ b/src/history-generator.js
@@ -1,0 +1,144 @@
+module.exports = function(objects) {
+	var history = {}
+
+	for (let obj of objects) {
+
+	}
+
+	return history
+}
+
+ var updateJson = function(oldCommitInfo, newCommitInfo, historyJson, callback) {
+    // convert this commit to an obj
+    branchToObj(newCommitInfo.commit, function(newCommitJson) {
+      // compare the jsons, returns new updated json
+      if (!oldCommitInfo.commit) {
+        //console.log("INITIAL COMMIT")
+        compareJson({}, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
+          callback(resultJson)
+        })
+      } else {
+        //console.log("UPDATING COMMIT")
+        branchToObj(oldCommitInfo.commit, function(oldCommitJson) {
+          compareJson(oldCommitJson, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
+            callback(resultJson)
+          })
+        })
+      }
+    })
+  }
+
+  // Compares two json files with optional historyjson, returning the difference as a history JSON w/ commit info
+  var compareJson = function(oldCommitJson, newCommitJson, historyJson, newCommitInfo, callback) {
+
+    var modified = false
+
+    // debug info (believe me its damn useful LOL)
+    // console.log("Comparing jsons")
+    // console.log("New: " + (typeof newCommitJson) + JSON.stringify(newCommitJson))
+    // console.log("Old: " + (typeof oldCommitJson) + JSON.stringify(oldCommitJson))
+    // console.log("Hist: " + (typeof historyJson) + JSON.stringify(historyJson))
+
+    // Iterate through all the keys in newCommitJson, looking for new attributes 
+    for (var i in newCommitJson) {
+
+      // If the attribute doesnt exist in the old Json OR the old json isnt an object..
+      if (!(typeof oldCommitJson == 'object') || !(i in oldCommitJson)) {
+        newVersion = newCommitJson[i]
+        console.log("New attribute " + i  + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
+        if (newVersion instanceof Array) {
+            // The newversion is an array
+
+            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
+
+        } else if (typeof newVersion == 'object') {
+          //The newversion is an object
+
+          //Compare the children json with empty json - makes all children new basically
+          compareJson({}, newVersion, {}, newCommitInfo, function(extractModified, jsonExtract) { 
+            // Add parent history
+            historyJson[i] = jsonExtract
+            historyJson["$hist_" + i] = "Created by " + newCommitInfo.author + " at " + newCommitInfo.date
+            modified = true
+          })
+        } else {
+          // The newversion is a variable
+
+          // Add it to the json and history 
+          historyJson[i] = newVersion
+          historyJson["$hist_" + i] = "Created with value '" + newVersion + "' by " + newCommitInfo.author + " at " + newCommitInfo.date
+          modified = true
+        }
+      }
+    }
+
+    // Iterate through all the keys in oldCommitJson, looking for updates and deletions
+    for (var i in oldCommitJson) {
+
+      // The key exists in both the old and new object
+      if (i in newCommitJson && (typeof newCommitJson == 'object')) {
+        oldVersion = oldCommitJson[i]
+        newVersion = newCommitJson[i]
+
+        // The old ver is not equal to the new ver
+        // Note - object comparison always returns false -> we need a 'modified' parameter in this circumstance 
+        if (oldVersion !== newVersion) {
+          // should be an index in history.json unless something is broken..
+          console.log("Updated attribute " + i + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
+          
+          // Additional information for any type conversion that occurs from old -> new
+          typeConversion = ""
+          if (typeof newVersion !== typeof oldVersion) {
+            typeConversion = " - Changed type from " + (typeof oldVersion) + " to " + (typeof newVersion)
+          } 
+
+          if (newVersion instanceof Array) {
+            // The newversion is an array
+
+            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
+
+            modified = true
+          } else if (typeof newVersion == 'object') {
+            // The newversion is an object
+
+            // If the old version is not an object, its gotta be removed
+            if (typeof oldVersion !== 'object') {
+              oldVersion = {}
+              historyJson[i] = {} 
+            }
+
+            // Compare the children json files, using the history for updates
+            compareJson(oldVersion, newVersion, historyJson[i], newCommitInfo, function(extractModified, jsonExtract) {
+              if (extractModified) {
+                // The extract was modified from old -> new
+                // Update parent history
+                historyJson[i] = jsonExtract
+                historyJson["$hist_" + i] = "Modified by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
+                modified = true
+              }
+            })
+          } else {
+            // The newversion is a variable
+            // Update variable & history
+            historyJson[i] = newVersion
+            historyJson["$hist_" + i] += "\nUpdated with value '" + newVersion + " by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
+            modified = true
+          }
+        }
+      } else {
+        // The attribute was deleted
+        if(historyJson[i]) {
+          delete historyJson[i]
+          modified = true
+        }
+
+        if (historyJson["$hist_" + i]) {
+          delete historyJson["$hist_" + i]
+          modified = true
+        }
+      }
+    }
+
+    // Return whether the json was modified + changed file
+    callback(modified, historyJson)
+  }

--- a/src/history-generator.js
+++ b/src/history-generator.js
@@ -1,144 +1,66 @@
-module.exports = function(objects) {
-	var history = {}
+module.exports = function(objects, history) {
+	history = history || {}
 
 	for (let obj of objects) {
-
+		updateJson(obj, history)
 	}
 
 	return history
 }
 
- var updateJson = function(oldCommitInfo, newCommitInfo, historyJson, callback) {
-    // convert this commit to an obj
-    branchToObj(newCommitInfo.commit, function(newCommitJson) {
-      // compare the jsons, returns new updated json
-      if (!oldCommitInfo.commit) {
-        //console.log("INITIAL COMMIT")
-        compareJson({}, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
-          callback(resultJson)
-        })
-      } else {
-        //console.log("UPDATING COMMIT")
-        branchToObj(oldCommitInfo.commit, function(oldCommitJson) {
-          compareJson(oldCommitJson, newCommitJson, historyJson, newCommitInfo, function(modified, resultJson) {
-            callback(resultJson)
-          })
-        })
-      }
-    })
+ var updateJson = function(obj, history) {
+ 	var commit = obj.$commit
+ 	delete obj.$commit
+
+ 	compareJson(obj, history, commit)
   }
 
   // Compares two json files with optional historyjson, returning the difference as a history JSON w/ commit info
-  var compareJson = function(oldCommitJson, newCommitJson, historyJson, newCommitInfo, callback) {
+  var compareJson = function(obj, history, commit) {
 
     var modified = false
 
-    // debug info (believe me its damn useful LOL)
-    // console.log("Comparing jsons")
-    // console.log("New: " + (typeof newCommitJson) + JSON.stringify(newCommitJson))
-    // console.log("Old: " + (typeof oldCommitJson) + JSON.stringify(oldCommitJson))
-    // console.log("Hist: " + (typeof historyJson) + JSON.stringify(historyJson))
-
-    // Iterate through all the keys in newCommitJson, looking for new attributes 
-    for (var i in newCommitJson) {
+    for (var propertyName in obj) {
+    	var historyProperty = '$hist_' + propertyName			
 
       // If the attribute doesnt exist in the old Json OR the old json isnt an object..
-      if (!(typeof oldCommitJson == 'object') || !(i in oldCommitJson)) {
-        newVersion = newCommitJson[i]
-        console.log("New attribute " + i  + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
-        if (newVersion instanceof Array) {
-            // The newversion is an array
+      	if (typeof(obj[propertyName]) != 'object') {
+      	// simple type
+      		if (!history[propertyName]) {
+		  		history[historyProperty] =  "Created by " + commit.author + " at " + commit.date
+		  		history[propertyName] = obj[propertyName]
+		  		modified = true
+		  	} else if (typeof(obj[propertyName]) != typeof(history[propertyName])) {
+		  		history[propertyName] = obj[propertyName]
+		  		history[historyProperty] =  "Modified by " + commit.author + " at " + commit.date + 'Type changed'
+		  		modified = true
+			} else if (obj[propertyName] != history[propertyName]) {
+	  			history[historyProperty] =  "Modified by " + commit.author + " at " + commit.date
+	  			history[propertyName] = obj[propertyName]
+	  			modified = true
+	  		}
+		} else {
+			if (!history[propertyName] || typeof(history[propertyName]) !== 'object') {
+		  		history[historyProperty] =  "Created by " + commit.author + " at " + commit.date
+		  		var childHistory = {}
+		  		var childModified = compareJson(obj[propertyName], childHistory, commit)
+		  		if (childModified) {
+		  			history[propertyName] = childHistory
+		  		}
 
-            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
+		  		modified = true
+		  		continue
+		  	} else {
+		  		var childModified = compareJson(obj[propertyName], history[propertyName], commit)
+		  		modified = childModified
+		  		if (childModified) {
+		  			history[historyProperty] =  "Modified by " + commit.author + " at " + commit.date
+		  		}
 
-        } else if (typeof newVersion == 'object') {
-          //The newversion is an object
+		  		continue
+		  	}
+		}
+	}
 
-          //Compare the children json with empty json - makes all children new basically
-          compareJson({}, newVersion, {}, newCommitInfo, function(extractModified, jsonExtract) { 
-            // Add parent history
-            historyJson[i] = jsonExtract
-            historyJson["$hist_" + i] = "Created by " + newCommitInfo.author + " at " + newCommitInfo.date
-            modified = true
-          })
-        } else {
-          // The newversion is a variable
-
-          // Add it to the json and history 
-          historyJson[i] = newVersion
-          historyJson["$hist_" + i] = "Created with value '" + newVersion + "' by " + newCommitInfo.author + " at " + newCommitInfo.date
-          modified = true
-        }
-      }
-    }
-
-    // Iterate through all the keys in oldCommitJson, looking for updates and deletions
-    for (var i in oldCommitJson) {
-
-      // The key exists in both the old and new object
-      if (i in newCommitJson && (typeof newCommitJson == 'object')) {
-        oldVersion = oldCommitJson[i]
-        newVersion = newCommitJson[i]
-
-        // The old ver is not equal to the new ver
-        // Note - object comparison always returns false -> we need a 'modified' parameter in this circumstance 
-        if (oldVersion !== newVersion) {
-          // should be an index in history.json unless something is broken..
-          console.log("Updated attribute " + i + " - " + newCommitInfo.author + " at " + newCommitInfo.date)
-          
-          // Additional information for any type conversion that occurs from old -> new
-          typeConversion = ""
-          if (typeof newVersion !== typeof oldVersion) {
-            typeConversion = " - Changed type from " + (typeof oldVersion) + " to " + (typeof newVersion)
-          } 
-
-          if (newVersion instanceof Array) {
-            // The newversion is an array
-
-            // TO DO ?!?! -  for loop of recursive calls w/ empty oldcommit
-
-            modified = true
-          } else if (typeof newVersion == 'object') {
-            // The newversion is an object
-
-            // If the old version is not an object, its gotta be removed
-            if (typeof oldVersion !== 'object') {
-              oldVersion = {}
-              historyJson[i] = {} 
-            }
-
-            // Compare the children json files, using the history for updates
-            compareJson(oldVersion, newVersion, historyJson[i], newCommitInfo, function(extractModified, jsonExtract) {
-              if (extractModified) {
-                // The extract was modified from old -> new
-                // Update parent history
-                historyJson[i] = jsonExtract
-                historyJson["$hist_" + i] = "Modified by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
-                modified = true
-              }
-            })
-          } else {
-            // The newversion is a variable
-            // Update variable & history
-            historyJson[i] = newVersion
-            historyJson["$hist_" + i] += "\nUpdated with value '" + newVersion + " by " + newCommitInfo.author + " at " + newCommitInfo.date + typeConversion
-            modified = true
-          }
-        }
-      } else {
-        // The attribute was deleted
-        if(historyJson[i]) {
-          delete historyJson[i]
-          modified = true
-        }
-
-        if (historyJson["$hist_" + i]) {
-          delete historyJson["$hist_" + i]
-          modified = true
-        }
-      }
-    }
-
-    // Return whether the json was modified + changed file
-    callback(modified, historyJson)
+	return modified
   }

--- a/src/repository.js
+++ b/src/repository.js
@@ -7,11 +7,12 @@ module.exports = function(path) {
   var gitExecute = function(command, callback) {
     var command = 'git ' + command
 
-    //console.log(command, path)
+   // console.log(command, path)
 
     exec(command, {cwd: path}, function(error, result) {
       if (error != null) {
         console.log("Error with command - " + command)
+        console.log(error)
         callback(result, error)
       }
       else {
@@ -44,8 +45,18 @@ module.exports = function(path) {
 
       // add array [ & ]
       var jsonString = '[' + commaRemoved + ']'
-      
+
       callback(JSON.parse(jsonString))
+    })
+  }
+
+  var log = function(logOptions, callback) {
+    if (typeof logOptions === 'function') {
+      callback = logOptions
+      logOptions = ''
+    }
+    gitExecute('log ' + logOptions, function(result) {
+      callback(result)
     })
   }
 
@@ -132,6 +143,7 @@ module.exports = function(path) {
   return {
       commit: commit,
       jsonLog: jsonLog,
+      log: log,
       init:init,
       pull: pull,
       push: push,

--- a/src/repository.js
+++ b/src/repository.js
@@ -7,7 +7,7 @@ module.exports = function(path) {
   var gitExecute = function(command, callback) {
     var command = 'git ' + command
 
-   // console.log(command, path)
+    //console.log(command, path)
 
     exec(command, {cwd: path}, function(error, result) {
       if (error != null) {

--- a/src/repository.js
+++ b/src/repository.js
@@ -28,9 +28,13 @@ module.exports = function(path) {
     gitExecute('commit -m "' + message + '"', callback)
   }
 
-  var jsonLog = function(callback) {
+  var jsonLog = function(logOptions, callback) {
+    if (typeof logOptions === 'function') {
+      callback = logOptions
+      logOptions = ''
+    }
 
-    gitExecute('log --pretty=format:"{ *commit*: *%H*, *author*: *%an <%ae>*, *date*: *%ad*, *message*: *%f*},"', function(data) {
+    gitExecute('log ' + logOptions + ' --pretty=format:"{ *commit*: *%H*, *author*: *%an <%ae>*, *date*: *%ad*, *message*: *%f*},"', function(data) {
 
       // replace *'s with "'s
       var quoted = data.split('*').join('"')
@@ -40,14 +44,8 @@ module.exports = function(path) {
 
       // add array [ & ]
       var jsonString = '[' + commaRemoved + ']'
-
+      
       callback(JSON.parse(jsonString))
-    })
-  }
-
-  var log = function(logOptions, callback) {
-    gitExecute('log ' + logOptions, function(result) {
-      callback(result)
     })
   }
 
@@ -134,7 +132,6 @@ module.exports = function(path) {
   return {
       commit: commit,
       jsonLog: jsonLog,
-      log: log,
       init:init,
       pull: pull,
       push: push,

--- a/test.js
+++ b/test.js
@@ -1,14 +1,15 @@
 describe('Vetus Tests', function() {
   this.timeout(40000)
-  // require('./tests/create')
-  // require('./tests/load')
-  // require('./tests/update')
-  // require('./tests/users')
-  // require('./tests/branch')
-  // require('./tests/merge')
-  // require('./tests/conflict')
-  // require('./tests/diff'),
-  // require('./tests/diff-child-properties'),
-  // require('./tests/diff-array')
+  require('./tests/create')
+  require('./tests/load')
+  require('./tests/update')
+  require('./tests/users')
+  require('./tests/branch')
+  require('./tests/merge')
+   require('./tests/conflict')
+  require('./tests/diff'),
+  require('./tests/diff-child-properties'),
+  require('./tests/diff-array')
+  require('./tests/history')
   require('./tests/history-generator')
 })

--- a/test.js
+++ b/test.js
@@ -1,13 +1,14 @@
 describe('Vetus Tests', function() {
-  this.timeout(15000)
-  require('./tests/create')
-  require('./tests/load')
-  require('./tests/update')
-  require('./tests/users')
-  require('./tests/branch')
-  require('./tests/merge')
-  require('./tests/conflict')
-  require('./tests/diff'),
-  require('./tests/diff-child-properties'),
-  require('./tests/diff-array')
+  this.timeout(40000)
+  // require('./tests/create')
+  // require('./tests/load')
+  // require('./tests/update')
+  // require('./tests/users')
+  // require('./tests/branch')
+  // require('./tests/merge')
+  // require('./tests/conflict')
+  // require('./tests/diff'),
+  // require('./tests/diff-child-properties'),
+  // require('./tests/diff-array')
+  require('./tests/history-generator')
 })

--- a/tests/conflict.js
+++ b/tests/conflict.js
@@ -31,7 +31,7 @@ describe('(Basic) Conflicts', function() {
                   saveCollection.data.first = { name: 'conflict' }
                   saveCollection.data.second = { name: 'second' }
                   saveCollection.save('commit2', function(err) {
-                    collection.merge('master', function(err) {
+                    saveCollection.merge('dev', function(err) {
                       vetus.collection({name: 'test', branch:'dev'}, function(branchCollection) {
                         branchCollection.load(function() {
                           branchData = branchCollection.data

--- a/tests/conflict.js
+++ b/tests/conflict.js
@@ -26,10 +26,10 @@ describe('(Basic) Conflicts', function() {
         saveCollection.createBranch('dev', function() {
           vetus.collection({name: 'test', branch: 'dev'}, function(collection) {
             collection.load(function() {
-              collection.data.first = { name: 'updated', other: 'test' }
+              collection.data.first = { name: 'updated' }
               collection.save('commit', function(err) {
                 saveCollection.load(function() {
-                  saveCollection.data.first = { john: 'lol', name: 'conflict', other: 'test'  }
+                  saveCollection.data.first = { john: 'lol', name: 'conflict' }
                   saveCollection.data.second = { name: 'second' }
                   saveCollection.save('commit2', function(err) {
                     saveCollection.merge('dev', function(err) {
@@ -40,10 +40,19 @@ describe('(Basic) Conflicts', function() {
                             vetus.collection({name: 'test'}, function(masterCollection) {
                               masterCollection.load(function() {
                                 masterData = masterCollection.data
-                                masterCollection.data.first = { john: 'loledit', name: 'conflictedx2', other: 'test' }
+                                masterCollection.data.first = { john: { name: 'loledit'} }
                                 masterCollection.save("commit3", function (){
-                                  masterCollection.updateHistory(function() {
-                                    done()
+                                  masterCollection.updateHistory(function(result) {
+                                    console.log("History of branch : ")
+                                    console.log(JSON.stringify(result, null, 2))
+                                    masterCollection.data.first = { john: 2 }
+                                    masterCollection.save("commit4", function (){
+                                      masterCollection.updateHistory(function(result2) {
+                                        console.log("History of branch : ")
+                                        console.log(JSON.stringify(result2, null, 2))
+                                        done()
+                                      })
+                                    })
                                   })
                                 })
                               })

--- a/tests/conflict.js
+++ b/tests/conflict.js
@@ -36,11 +36,18 @@ describe('(Basic) Conflicts', function() {
                       vetus.collection({name: 'test', branch:'dev'}, function(branchCollection) {
                         branchCollection.load(function() {
                           branchData = branchCollection.data
-                          vetus.collection({name: 'test'}, function(masterCollection) {
-                            masterCollection.load(function() {
-                              masterData = masterCollection.data
-                              done()
-                            })
+                          saveCollection.updateHistory(function() {
+                            vetus.collection({name: 'test'}, function(masterCollection) {
+                              masterCollection.load(function() {
+                                masterData = masterCollection.data
+                                masterCollection.data.first = { john: 'loledit', name: 'conflictedx2', other: 'test' }
+                                masterCollection.save("commit3", function (){
+                                  masterCollection.updateHistory(function() {
+                                    done()
+                                  })
+                                })
+                              })
+                            })                          
                           })
                         })
                       })

--- a/tests/conflict.js
+++ b/tests/conflict.js
@@ -11,7 +11,6 @@ describe('(Basic) Conflicts', function() {
 
   var branchData
   var masterData
-  var blameJson
 
   before(function(done) {
     if (fs.existsSync(testDirectory)) {
@@ -21,7 +20,7 @@ describe('(Basic) Conflicts', function() {
     fs.mkdirSync(testDirectory)
 
     vetus.collection({name: 'test'}, function(saveCollection) {
-      saveCollection.data.first = { name: 'first', other: 'test' }
+      saveCollection.data.first = { name: 'first' }
       saveCollection.save('commit', function(err) {
         saveCollection.createBranch('dev', function() {
           vetus.collection({name: 'test', branch: 'dev'}, function(collection) {
@@ -29,34 +28,18 @@ describe('(Basic) Conflicts', function() {
               collection.data.first = { name: 'updated' }
               collection.save('commit', function(err) {
                 saveCollection.load(function() {
-                  saveCollection.data.first = { john: 'lol', name: 'conflict' }
+                  saveCollection.data.first = { name: 'conflict' }
                   saveCollection.data.second = { name: 'second' }
                   saveCollection.save('commit2', function(err) {
-                    saveCollection.merge('dev', function(err) {
+                    collection.merge('master', function(err) {
                       vetus.collection({name: 'test', branch:'dev'}, function(branchCollection) {
                         branchCollection.load(function() {
                           branchData = branchCollection.data
-                          saveCollection.updateHistory(function() {
-                            vetus.collection({name: 'test'}, function(masterCollection) {
-                              masterCollection.load(function() {
-                                masterData = masterCollection.data
-                                masterCollection.data.first = { john: { name: 'loledit'} }
-                                masterCollection.save("commit3", function (){
-                                  masterCollection.updateHistory(function(result) {
-                                    console.log("History of branch : ")
-                                    console.log(JSON.stringify(result, null, 2))
-                                    masterCollection.data.first = { john: 2 }
-                                    masterCollection.save("commit4", function (){
-                                      masterCollection.updateHistory(function(result2) {
-                                        console.log("History of branch : ")
-                                        console.log(JSON.stringify(result2, null, 2))
-                                        done()
-                                      })
-                                    })
-                                  })
-                                })
-                              })
-                            })                          
+                          vetus.collection({name: 'test'}, function(masterCollection) {
+                            masterCollection.load(function() {
+                              masterData = masterCollection.data
+                              done()
+                            })
                           })
                         })
                       })
@@ -72,7 +55,7 @@ describe('(Basic) Conflicts', function() {
   })
 
   after(function() {
-    //rimraf(testDirectory)
+    rimraf(testDirectory)
   })
 
   it('Dev and Master not merged', function(done) {
@@ -87,5 +70,4 @@ describe('(Basic) Conflicts', function() {
     assert(!branchData.second)
     done()
   })
-
 })

--- a/tests/conflict.js
+++ b/tests/conflict.js
@@ -11,6 +11,7 @@ describe('(Basic) Conflicts', function() {
 
   var branchData
   var masterData
+  var blameJson
 
   before(function(done) {
     if (fs.existsSync(testDirectory)) {
@@ -20,15 +21,15 @@ describe('(Basic) Conflicts', function() {
     fs.mkdirSync(testDirectory)
 
     vetus.collection({name: 'test'}, function(saveCollection) {
-      saveCollection.data.first = { name: 'first' }
+      saveCollection.data.first = { name: 'first', other: 'test' }
       saveCollection.save('commit', function(err) {
         saveCollection.createBranch('dev', function() {
           vetus.collection({name: 'test', branch: 'dev'}, function(collection) {
             collection.load(function() {
-              collection.data.first = { name: 'updated' }
+              collection.data.first = { name: 'updated', other: 'test' }
               collection.save('commit', function(err) {
                 saveCollection.load(function() {
-                  saveCollection.data.first = { name: 'conflict' }
+                  saveCollection.data.first = { john: 'lol', name: 'conflict', other: 'test'  }
                   saveCollection.data.second = { name: 'second' }
                   saveCollection.save('commit2', function(err) {
                     saveCollection.merge('dev', function(err) {
@@ -70,4 +71,5 @@ describe('(Basic) Conflicts', function() {
     assert(!branchData.second)
     done()
   })
+
 })

--- a/tests/history-generator.js
+++ b/tests/history-generator.js
@@ -1,0 +1,20 @@
+var assert = require('chai').assert
+var historyGenerator = require('./../src/history-generator')
+
+describe('When generating history', function() {
+
+  var objects = [
+    {name: 'first', $user: 'jamie', $commit: 'my-commit', $date: '1/1/2012'},
+    {name: 'second'}
+  ]
+
+  var history = historyGenerator()
+
+  it('latest value shown', function() {
+    assert(history.name === 'second')
+  })
+
+  it('latest value shown', function() {
+    assert(history.$hist_name === 'updated by jamie in commit my-commit on 1/1/2012')
+  })
+})

--- a/tests/history-generator.js
+++ b/tests/history-generator.js
@@ -4,17 +4,18 @@ var historyGenerator = require('./../src/history-generator')
 describe('When generating history', function() {
 
   var objects = [
-    {name: 'first', $user: 'jamie', $commit: 'my-commit', $date: '1/1/2012'},
-    {name: 'second'}
+    {name: 'first', $commit: { author:'jamie', date:'1/1/12'}},
+    {name: 'second', $commit: { author: 'rob', date: '2/2/12' }}
   ]
 
-  var history = historyGenerator()
+  var history = historyGenerator(objects)
 
   it('latest value shown', function() {
     assert(history.name === 'second')
   })
 
   it('latest value shown', function() {
-    assert(history.$hist_name === 'updated by jamie in commit my-commit on 1/1/2012')
+    assert(history.$hist_name, '$hist_name node missing')
+    assert(history.$hist_name === 'Modified by rob at 2/2/12', '$hist_name incorrect value: ' + history.$hist_name)
   })
 })

--- a/tests/history.js
+++ b/tests/history.js
@@ -1,0 +1,75 @@
+var assert = require('chai').assert
+var fs = require('fs')
+var path = require('path')
+var rimraf = require('rimraf').sync
+
+var testDirectory = path.join(__dirname, '..', '..', 'test-temp')
+
+var vetus = require('./../app')({ path: testDirectory })
+
+describe('Repository history testing', function() {
+
+  var historyObj
+  var firstHistory = "$hist_first"
+  var secondHistory = "$hist_second"
+
+  before(function(done) {
+    if (fs.existsSync(testDirectory)) {
+      rimraf(testDirectory)
+    }
+
+    fs.mkdirSync(testDirectory)
+
+    vetus.collection({name: 'test'}, function(saveCollection) {
+      saveCollection.data.first = { name: 'created', other: 'created', stringToObj: 'created' }
+      saveCollection.save('commit', function(err) {
+        saveCollection.data.first = { other: 'updated', stringToObj: { name: 'created'} }
+        saveCollection.data.second = { name: { old : "old" } }
+        saveCollection.save('commit2', function(err) {
+          vetus.collection({name: 'test', user:'jamie'}, function(userCollection) {
+            userCollection.data.second = { name: 'updated' }
+            userCollection.save('commit3' ,function(err) { 
+              userCollection.history(function(history) {
+                historyObj = history
+                done()       
+              })        
+            })
+          })
+        })
+      })
+    })
+  })
+
+
+  after(function() {
+    rimraf(testDirectory)
+  })
+
+  it('Contains history', function(done) {
+    assert(historyObj[firstHistory], "Missing first history")
+    assert(historyObj[secondHistory], "Missing second history")
+    done()
+  })
+  
+  it('First created & updated', function(done) {
+    assert(historyObj.first.name == 'created', "Not created")
+    assert(historyObj.first.other == 'updated', "Not updated")
+    done()
+  })
+
+  it('Attribute converted, string -> obj', function(done) {
+    assert((typeof historyObj.first.stringToObj) == 'object', "It didnt convert")
+    done()
+  })
+
+  it('Attribute converted,  obj -> string', function(done) {
+    assert((typeof historyObj.second.name) == 'string', "It didnt convert")
+    done()
+  })
+
+  it('Multiple user history correct' ,function(done) {
+    assert(historyObj.first.$hist_name.includes('_default'), "Failed default commits")
+    assert(historyObj.second.$hist_name.includes('jamie'), "Failed user commits")
+    done()
+  })
+})

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -38,11 +38,7 @@ describe('(Basic) Merging', function() {
                           vetus.collection({name: 'test'}, function(masterCollection) {
                             masterCollection.load(function() {
                               masterData = masterCollection.data
-                              masterCollection.getHistory('-p -5', function(log) {
-                                masterLog = log
-                                // console.log(masterLog)
-                                done()
-                              })
+                              done()
                             })
                           })
                         })
@@ -74,11 +70,6 @@ describe('(Basic) Merging', function() {
 
   it('Dev has not changed', function(done) {
     assert(!branchData.second)
-    done()
-  })
-
-  it('Log succeeded', function(done) {
-    assert(masterLog)
     done()
   })
 })

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -31,7 +31,7 @@ describe('(Basic) Merging', function() {
                 saveCollection.load(function() {
                   saveCollection.data.second = { name: 'second' }
                   saveCollection.save('added second to master', function(err) {
-                    collection.merge('master', function(err) {
+                    saveCollection.merge('dev', function(err) {
                       vetus.collection({name: 'test', branch:'dev'}, function(branchCollection) {
                         branchCollection.load(function() {
                           branchData = branchCollection.data


### PR DESCRIPTION
_Squashed extraneous commits_ 
- Added history for branches. Call collection.history to get a history object (JSON) which contains blame information (1 deep, although can be extended easily) on changes to all attributes in the collection.
- Added tests for history.
- Reverted some changes to merge & conflict testing.
- Added logoptions to jsonLog.
