### PR TITLE
WIP: Collection versions tag against base repo, not user repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ about this until search is implemented. This could just be a seperate vetus path
 
 ## Changelog
 
+### `0.5.2`
+- Collection versions tag against base repo, not user repo #45
+
 ### `0.5.1`
-- Added collection `allVersions()` function
+- Added collection `allVersions()` function #44
 
 ### `0.5.0`
-- Versioning support using git tags
+- Versioning support using git tags #43

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vetus",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vetus",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "",
   "keywords": [
     "git",

--- a/src/collection.js
+++ b/src/collection.js
@@ -329,32 +329,28 @@ module.exports = function(options) {
   }
 
   const getVersion = callback => {
-    preCommand(() => {
-      barerepo.getLatestTag(branch, tag => {
-        if (!tag) return callback(undefined)
+    barerepo.getLatestTag(branch, tag => {
+      if (!tag) return callback(undefined)
 
-        const v = tag.match(/v_(.*)_/)
-        if (!v || !v.length) return callback(undefined)
+      const v = tag.match(/v_(.*)_/)
+      if (!v || !v.length) return callback(undefined)
 
-        const [major, minor] = v[1].split(/\./).map(Number)
-        callback({ major, minor })
-      })
+      const [major, minor] = v[1].split(/\./).map(Number)
+      callback({ major, minor })
     })
   }
 
   const allVersions = callback => {
-    preCommand(() => {
-      barerepo.getTags('v_*_', tags => {
-        if (!tags) return callback(undefined)
+    barerepo.getTags('v_*_', tags => {
+      if (!tags) return callback(undefined)
 
-        const versions = tags
-          .map(t => t.match(/v_(.*)_/))
-          .filter(t => t)
-          .map(t => t[1].split(/\./).map(Number))
-          .map(([major, minor]) => ({major, minor}))
+      const versions = tags
+        .map(t => t.match(/v_(.*)_/))
+        .filter(t => t)
+        .map(t => t[1].split(/\./).map(Number))
+        .map(([major, minor]) => ({major, minor}))
 
-        return callback(versions)
-      })
+      return callback(versions)
     })
   }
 
@@ -365,9 +361,11 @@ module.exports = function(options) {
     }
 
     const newTag = `v_${major}.${minor}_`
-    repo.preTagCommit(branch, newTag, targetCommit => {
-      barerepo.tag(newTag, targetCommit, ok => {
-        return callback(ok && version)
+    preCommand(() => {
+      repo.preTagCommit(branch, newTag, targetCommit => {
+        barerepo.tag(newTag, targetCommit, ok => {
+          return callback(ok && version)
+        })
       })
     })
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -330,7 +330,7 @@ module.exports = function(options) {
 
   const getVersion = callback => {
     preCommand(() => {
-      barerepo.getLatestTag(tag => {
+      barerepo.getLatestTag(branch, tag => {
         if (!tag) return callback(undefined)
 
         const v = tag.match(/v_(.*)_/)
@@ -365,8 +365,8 @@ module.exports = function(options) {
     }
 
     const newTag = `v_${major}.${minor}_`
-    repo.preTagCommit(branch, newTag, () => {
-      barerepo.tag(newTag, ok => {
+    repo.preTagCommit(branch, newTag, targetCommit => {
+      barerepo.tag(newTag, targetCommit, ok => {
         return callback(ok && version)
       })
     })

--- a/src/collection.js
+++ b/src/collection.js
@@ -330,7 +330,7 @@ module.exports = function(options) {
 
   const getVersion = callback => {
     preCommand(() => {
-      repo.getLatestTag(tag => {
+      barerepo.getLatestTag(tag => {
         if (!tag) return callback(undefined)
 
         const v = tag.match(/v_(.*)_/)
@@ -344,7 +344,7 @@ module.exports = function(options) {
 
   const allVersions = callback => {
     preCommand(() => {
-      repo.getTags('v_*_', tags => {
+      barerepo.getTags('v_*_', tags => {
         if (!tags) return callback(undefined)
 
         const versions = tags
@@ -364,7 +364,12 @@ module.exports = function(options) {
       return callback(false)
     }
 
-    repo.tag(`v_${major}.${minor}_`, ok => callback(ok && version))
+    const newTag = `v_${major}.${minor}_`
+    repo.preTagCommit(branch, newTag, () => {
+      barerepo.tag(newTag, ok => {
+        return callback(ok && version)
+      })
+    })
   }
 
   const versionBump = (type, callback) => {

--- a/src/repository.js
+++ b/src/repository.js
@@ -220,13 +220,17 @@ module.exports = function (path) {
     gitExecute('rev-parse HEAD', callback)
   }
 
-  const tag = (tagName, callback) => {
+  const preTagCommit = (branch, tagName, callback) => {
     gitExecute(`commit --allow-empty -m "Commit for tag ${tagName}"`, () => {
-      gitExecute(`tag ${tagName}`, (_, err) => {
-        if (err) return callback(false)
+      push(`origin ${branch}`, (_, err) => callback(!err))
+    })
+  }
 
-        return callback(true)
-      })
+  const tag = (tagName, callback) => {
+    gitExecute(`tag ${tagName}`, (_, err) => {
+      if (err) return callback(false)
+
+      return callback(true)
     })
   }
 
@@ -277,6 +281,7 @@ module.exports = function (path) {
     execute,
     isNew,
     currentCommit,
+    preTagCommit,
     tag,
     getLatestTag,
     getTags

--- a/src/repository.js
+++ b/src/repository.js
@@ -222,20 +222,23 @@ module.exports = function (path) {
 
   const preTagCommit = (branch, tagName, callback) => {
     gitExecute(`commit --allow-empty -m "Commit for tag ${tagName}"`, () => {
-      push(`origin ${branch}`, (_, err) => callback(!err))
+      push(`origin HEAD:${branch}`, (_, err) => {
+        if (err) return callback(undefined)
+        currentCommit(result => callback((result || '').trim() || undefined))
+      })
     })
   }
 
-  const tag = (tagName, callback) => {
-    gitExecute(`tag ${tagName}`, (_, err) => {
+  const tag = (tagName, targetCommit, callback) => {
+    gitExecute(`tag ${tagName} ${targetCommit}`, (_, err) => {
       if (err) return callback(false)
 
       return callback(true)
     })
   }
 
-  const getLatestTag = callback => {
-    gitExecute('describe --tags --abbrev=0', (result, err) => {
+  const getLatestTag = (branch, callback) => {
+    gitExecute(`describe --tags --abbrev=0 ${branch}`, (result, err) => {
       if (err) return callback(undefined)
 
       return callback((result || '').trim() || undefined)


### PR DESCRIPTION
Tagging against the user repo meant that a `collection.getVersion(...)` as a different user would return `undefined` due to `git describe --tags --abbrev=0` failing.

Now there is a 'pre tag' commit authored by the user & pushed to origin, and the actual tagging is carried out against the base repo.